### PR TITLE
Pylinker does not run without modification

### DIFF
--- a/pylnker.py
+++ b/pylnker.py
@@ -396,5 +396,5 @@ if __name__ == "__main__":
         usage()
     
     # parse .lnk file
-    out = parse_lnk(sys.argv[2])
+    out = parse_lnk(sys.argv[1])
     print "out: ",out


### PR DESCRIPTION
Greetings--

At line 395, it is mandated that the total number of command-line arguments must be **two**:

```
if len(sys.argv) != 2:
        usage()
```

...this causes a problem because at 399, the parse_lnk() function is invoked using the non-existent **third** command-line argument:

```
# parse .lnk file
out = parse_lnk(sys.argv[2])
print "out: ",out
```

As a result, an IndexError exception is thrown:

```
./pylnker.py linkFile.lnk 
Traceback (most recent call last):
  File "pylnker.py", line 399, in <module>
    out = parse_lnk(sys.argv[2])
IndexError: list index out of range
```

Unless I'm missing something, (very possible), Pylinker cannot run in its current state. The change I propose is:

```
# parse .lnk file
out = parse_lnk(sys.argv[1])
print "out: ",out
```

Tested with success:

```
out:  Lnk File: link.lnk
Link Flags: HAS SHELLIDLIST | POINTS TO FILE/DIR | NO DESCRIPTION | HAS RELATIVE PATH STRING | NO WORKING DIRECTORY | NO CMD LINE ARGS | HAS CUSTOM ICON
File Attributes: ARCHIVE
Create Time:   2014-04-14 11:02:00
Access Time:   2015-12-12 10:21:36.234324
Modified Time: 2014-04-14 11:02:00
Target length: 2604328
Icon Index: 0
ShowWnd: SW_NORMAL
HotKey: 0
Target is on local volume
Volume Type: Fixed (Hard Disk)
Volume Serial: e8aabf9f
Vol Label: 
Base Path: C:\Program Files (x86)\AccessData\Registry Viewer\RegistryViewer.exe
(App Path:) Remaining Path: 
Relative Path: ..\..\..\Program Files (x86)\AccessData\Registry Viewer\RegistryViewer.exe
Icon filename: C:\WINDOWS\Installer\{1417EF62-3892-403A-93DD-D0B483197E8F}\NewShortcut2_B5FCC329C01247FB95773B9A66CE4F9B.exe
```

Thanks!

Adam
